### PR TITLE
Pull request/a9a8d91c

### DIFF
--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -8,7 +8,7 @@ using Docile: @doc
 import Base: first, last
 
 export IntervalTree, IntervalMap, AbstractInterval, Interval, IntervalValue, depth,
-       hasintersection, from, first, last
+       hasintersection, from, first, last, print, show
 
 include("slice.jl")
 
@@ -49,19 +49,19 @@ first{K, V}(i::IntervalValue{K, V}) = i.first
 last{K, V}(i::IntervalValue{K, V}) = i.last
 value{K, V}(i::IntervalValue{K, V}) = i.value
 
+Base.print(io::IO, x::Interval) = print(io, "\n($(first(x)),$(last(x)))")
 function Base.show(io::IO, x::Interval)
     t = typeof(x)::DataType
     show(io, t)
-    print(io,  "\n($(first(x)),$(last(x)))")
+    print(x)
 end
 
+Base.print(io::IO, x::IntervalValue) = print(io, "\n($(first(x)),$(last(x))) => $(value(x))")
 function Base.show(io::IO, x::IntervalValue)
     t = typeof(x)::DataType
     show(io, t)
-    print(io,  "\n($(first(x)),$(last(x))) => $(value(x))")
+    print(x)
 end
-
-
 
 # Each of these types is indexes by K, V, B, where
 #   K : Interval type. Intervals are represented as (K, K) tuples.
@@ -232,6 +232,29 @@ end
 
 # Default B-tree order
 typealias IntervalTree{K, V} IntervalBTree{K, V, 64}
+
+# Show
+
+function Base.show(io::IO, it::IntervalTree)
+    t = typeof(it)::DataType
+    show(io, t)
+    n = length(it)
+    if length(it) > 6
+        # Hacky random access ...
+        for (i, x) in enumerate(it)
+            i < 4 && print(x)
+        end
+        print("\n\u22EE") # Vertical ellipsis
+        for (i, x) in enumerate(it)
+            i > (n-3) && print(x)
+        end
+    else
+        for x in it
+            print(x)
+        end
+    end
+end
+
 
 
 # Length

--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -47,6 +47,7 @@ end
 
 first{K, V}(i::IntervalValue{K, V}) = i.first
 last{K, V}(i::IntervalValue{K, V}) = i.last
+value{K, V}(i::IntervalValue{K, V}) = i.value
 
 
 # Each of these types is indexes by K, V, B, where

--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -49,6 +49,19 @@ first{K, V}(i::IntervalValue{K, V}) = i.first
 last{K, V}(i::IntervalValue{K, V}) = i.last
 value{K, V}(i::IntervalValue{K, V}) = i.value
 
+function Base.show(io::IO, x::Interval)
+    t = typeof(x)::DataType
+    show(io, t)
+    print(io,  "\n($(first(x)),$(last(x)))")
+end
+
+function Base.show(io::IO, x::IntervalValue)
+    t = typeof(x)::DataType
+    show(io, t)
+    print(io,  "\n($(first(x)),$(last(x))) => $(value(x))")
+end
+
+
 
 # Each of these types is indexes by K, V, B, where
 #   K : Interval type. Intervals are represented as (K, K) tuples.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,17 @@ using IntervalTrees
 import IntervalTrees: Slice, InternalNode, LeafNode, Interval, IntervalBTree
 
 
+# Getters
+facts("Getters") do
+    i = Interval(5, 6)
+    iv = IntervalValue(10, 11, "FOO")
+    @fact first(i)  => 5
+    @fact last(i)   => 6
+    @fact first(iv) => 10
+    @fact last(iv)  => 11
+    @fact value(iv) => "FOO"
+end
+
 # Generating random intervals
 srand(12345)
 const maxend = round(Int, 1e9)


### PR DESCRIPTION
This pull request suggests some additional pretty printing for IntervalTrees.  For IntervalTrees with a length > 6 I print an abbreviated output. I did some hacky stuff to iterate over parts of the tree. It would be lovely to have `getindex`. Since you have `length` and `sort!`, I think `getindex` would make sense, especially if this is to be used like R's IRanges.
