### PR TITLE
suppress deprecated warnings

### DIFF
--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -658,7 +658,7 @@ end
 
 # Indicate what steps are need to account for an updated child.
 immutable KeyFate
-    value::Uint8
+    value::UInt8
 end
 
 const KEYFATE_NONE         = KeyFate(0) # no changes
@@ -1183,7 +1183,7 @@ function Base.start{K, V, B}(it::IntervalIntersectionIterator{K, V, B})
 end
 
 
-function Base.next{K, V, B}(it::IntervalIntersectionIterator{K, V, B}, ::Nothing)
+function Base.next{K, V, B}(it::IntervalIntersectionIterator{K, V, B}, ::(@compat Void))
     intersection = it.intersection
     entry = intersection.node.entries[intersection.index]
     nextintersection!(intersection.node, intersection.index,
@@ -1192,7 +1192,7 @@ function Base.next{K, V, B}(it::IntervalIntersectionIterator{K, V, B}, ::Nothing
 end
 
 
-function Base.done{K, V, B}(it::IntervalIntersectionIterator{K, V, B}, ::Nothing)
+function Base.done{K, V, B}(it::IntervalIntersectionIterator{K, V, B}, ::(@compat Void))
     return it.intersection.index == 0
 end
 


### PR DESCRIPTION
This will suppress deprecated warnings that annoy me on v0.4.0-rc2.

```
INFO: Recompiling stale cache file /Users/kenta/.julia/lib/v0.4/IntervalTrees.ji for module IntervalTrees.
INFO: Recompiling stale cache file /Users/kenta/.julia/lib/v0.4/Docile.ji for module Docile.
WARNING: Base.Uint8 is deprecated, use UInt8 instead.
WARNING: Base.Uint8 is deprecated, use UInt8 instead.
WARNING: Base.Uint8 is deprecated, use UInt8 instead.
WARNING: Base.Uint8 is deprecated, use UInt8 instead.
WARNING: Base.Uint8 is deprecated, use UInt8 instead.
WARNING: Base.Nothing is deprecated, use Void instead.
WARNING: Base.Nothing is deprecated, use Void instead.
Getters
```