### PR TITLE
Some intersect optimizations.

### DIFF
--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -1126,15 +1126,29 @@ function nextintersection!{K, V, B}(t::LeafNode{K, V, B}, i::Integer,
             j += 1
         end
         j = 1
-        if isnull(t.right)
-            break
-        end
-        t = get(t.right)
-        if minstart(t) > last(query)
-            break
+
+        # move to the next leaf node, skipping those we can rule out
+        while true
+            if isnull(t.right)
+                @goto NO_INTERSECTION
+            end
+
+            t = get(t.right)
+
+            if minstart(t) > last(query)
+                @goto NO_INTERSECTION
+            end
+
+            # TODO: A better approach that might solve the issue with super-long
+            # intervals is to try to walk back up the tree and do a logarithmic
+            # search for the next intersection.
+            if t.maxend >= first(query)
+                break
+            end
         end
     end
 
+    @label NO_INTERSECTION
     out.index = 0
     return
 end

--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -228,7 +228,7 @@ end
 
 
 # Default B-tree order
-typealias IntervalTree{K, V} IntervalBTree{K, V, 64}
+typealias IntervalTree{K, V} IntervalBTree{K, V, 16}
 
 # Show
 
@@ -1032,14 +1032,16 @@ function firstintersection!{K, V, B}(t::InternalNode{K, V, B},
         return
     end
 
-    for (i, child) in enumerate(t.children)
-        if child.maxend >= first(query) && (i == 1 || t.keys[i-1].first <= last(query))
-            firstintersection!(child, query, out)
-            if out.index > 0
-                return
-            end
-        elseif minstart(child) > last(query)
+    (query_first, query_last) = (first(query), last(query))
+
+    for i in 1:length(t.children)
+        if i > 1 && unsafe_getindex(t.keys, i-1).first > query_last
             break
+        end
+
+        firstintersection!(unsafe_getindex(t.children, i), query, out)
+        if out.index > 0
+            return
         end
     end
 

--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -1294,7 +1294,7 @@ function Base.start{K, V1, B1, V2, B2}(it::IntersectionIterator{K, V1, B1, V2, B
         t1_state = start(it.t1)
         while !done(it.t1, t1_state)
             t1_value, t1_state = next(it.t1, t1_state)
-            firstintersection!(it.t2, t1_value, it.intersection)
+            firstintersection!(it.t2, t1_value, Nullable{V2}(), it.intersection)
             if it.intersection.index != 0
                 it.t1_state = t1_state
                 it.t1_value = t1_value
@@ -1386,7 +1386,7 @@ function Base.next{K, V1, B1, V2, B2}(it::IntersectionIterator{K, V1, B1, V2, B2
         t1_value = it.t1_value
         while intersection.index == 0 && !done(t1, t1_state)
             t1_value, t1_state = next(t1, t1_state)
-            firstintersection!(t2, t1_value, intersection)
+            firstintersection!(t2, t1_value, Nullable{V2}(), intersection)
         end
         it.isdone = intersection.index == 0
         it.t1_state = t1_state

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -563,7 +563,7 @@ end
     @test IntervalTrees.findidx(node, x) == 0
 
     result = IntervalTrees.Intersection{K, V, B}()
-    IntervalTrees.firstintersection!(node, x, result)
+    IntervalTrees.firstintersection!(node, x, Nullable{V}(), result)
     @test result.index == 0
 
     @test IntervalTrees.firstfrom(node, 1) == (node, 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,8 +42,12 @@ end
 
 
 function validkeys(node::IntervalTrees.InternalNode, minint, maxint)
-    for child in node.children
+    for (i, child) in enumerate(node.children)
         if child.maxend > node.maxend
+            return false
+        end
+
+        if child.maxend != node.maxends[i]
             return false
         end
     end
@@ -572,8 +576,11 @@ end
     t = IntervalBTree{K, V, B}()
     t.root = InternalNode{K, V, B}()
     push!(t.root.children, LeafNode{K, V, B}())
+    push!(t.root.maxends, 1)
     push!(t.root.keys, x)
     push!(t.root.children[1].entries, IntervalValue{Int, Int}(1, 1, 1))
+    t.root.maxend = 1
+    t.root.children[1].maxend = 1
     delete!(t, (1,1))
     @test isa(t.root, LeafNode)
 


### PR DESCRIPTION
I saw https://github.com/BioJulia/Bio.jl/issues/340 and it prompted me try to figure out why IntervalTrees does so poorly there.

These changes help make it competitive. But there is still a big issue. The intervals tested in that benchmark contain entries that span entire chromosomes.
```
Chr1    TAIR10  chromosome      1       30427671        .       .       .       ID=Chr1;Name=Chr1
```
This is the worst case for the intersect algorithm in IntervalTrees, causing it to become basically a linear search. I'm not sure what do about that. I assumed, maybe incorrectly, when writing this that extremely long intervals were rare. This is maybe an inherent shortcoming of IntervalTrees that suggests we should use NCList.

Feel free to leave this open and I'll add commits if I have any epiphanies.

