### PR TITLE
Optimization

### DIFF
--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -368,7 +368,7 @@ end
 # ---------
 
 
-immutable IntervalBTreeIteratorState{K, V, B}
+type IntervalBTreeIteratorState{K, V, B}
     leaf::Nullable{LeafNode{K, V, B}}
     i::Int
 end
@@ -389,9 +389,10 @@ function Base.next{K, V, B}(t::IntervalBTree{K, V, B},
     leaf = get(state.leaf)
     entry = leaf.entries[state.i]
     if state.i < length(leaf)
-        state = IntervalBTreeIteratorState{K, V, B}(leaf, state.i + 1)
+        state.i += 1
     else
-        state = IntervalBTreeIteratorState{K, V, B}(leaf.right, 1)
+        state.leaf = leaf.right
+        state.i = 1
     end
     return entry, state
 end

--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -24,8 +24,14 @@ a value of type `T`, and `first(i) <= last(i)` must always be true.
 """
 @compat abstract type AbstractInterval{T} end
 
-function Base.isless(u::AbstractInterval, v::AbstractInterval)
+
+function basic_isless(u::AbstractInterval, v::AbstractInterval)
     return first(u) < first(v) || (first(u) == first(v) && last(u) < last(v))
+end
+
+
+function Base.isless(u::AbstractInterval, v::AbstractInterval)
+    return basic_isless(u, v)
 end
 
 
@@ -952,7 +958,7 @@ function findidx{K, V, B}(t::LeafNode{K, V, B}, key::AbstractInterval{K})
     if isempty(t.entries)
         return 0
     end
-    return searchsortedfirst(t.entries, key)
+    return searchsortedfirst(t.entries, key, lt=basic_isless)
 end
 
 function findidx{K, V, B}(t::InternalNode{K, V, B}, key::AbstractInterval{K})
@@ -1116,7 +1122,8 @@ function firstintersection!{K, V, B}(t::LeafNode{K, V, B},
         return
     end
 
-    i = isnull(lower) ? 1 : 1 + searchsortedlast(t.entries, get(lower))
+    i = isnull(lower) ? 1 : 1 + searchsortedlast(t.entries, get(lower),
+                                                 lt=basic_isless)
 
     while i <= length(t)
         if intersects(t.entries[i], query)
@@ -1206,7 +1213,6 @@ function nextintersection!{K, V, B}(t::LeafNode{K, V, B}, i::Integer,
         end
     end
 
-    @label NO_INTERSECTION
     out.index = 0
     return
 end

--- a/src/IntervalTrees.jl
+++ b/src/IntervalTrees.jl
@@ -1616,12 +1616,12 @@ function Base.intersect{K, V1, B1, V2, B2}(t1::IntervalBTree{K, V1, B1},
                                            t2::IntervalBTree{K, V2, B2};
                                            method=:auto)
     # We decide heuristically which intersection algorithm to use.
-    n = length(t1)
-    m = length(t2)
+    m = length(t1)
+    n = length(t2)
 
     if method == :auto
         iterative_cost  = n + m
-        successive_cost = n * log(1 + m)
+        successive_cost = 0.25 * m * log(1 + n) + 1e5
         if iterative_cost < successive_cost
             return IntersectionIterator{K, V1, B1, V2, B2}(t1, t2, false)
         else

--- a/src/slice.jl
+++ b/src/slice.jl
@@ -116,3 +116,39 @@ end
 function Base.searchsortedfirst(s::Slice, x)
     return searchsortedfirst(s.data, x, 1, s.n, Base.Order.Forward)
 end
+
+
+
+function slice_insert!{T}(xs::Vector{T}, count::Integer, i::Integer, value::T)
+    if count < length(xs) && 1 <= i <= count + 1
+        if isbits(T)
+            unsafe_copy!(pointer(xs, i+1),
+                         pointer(xs, i), count - i + 1)
+        else
+            for k in 0:(count - i)
+                @inbounds xs[count+1-k] = xs[count-k]
+            end
+        end
+        @inbounds xs[i] = value
+        count += 1
+        return count
+    else
+        throw(BoundsError())
+    end
+end
+
+
+function slice_splice!{T}(xs::Vector{T}, count::Integer, i::Integer)
+    if 1 <= i <= count
+        @inbounds x = xs[i]
+        for j in i:count-1
+            @inbounds xs[j] = xs[j + 1]
+        end
+        count -= 1
+        return x, count
+    else
+        throw(BoundsError())
+    end
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,7 @@ end
 
 
 function validkeys(node::IntervalTrees.LeafNode, minint, maxint)
-    for entry in node.entries
+    for entry in node.entries[1:node.count]
         if !(minint <= entry <= maxint) || last(entry) > node.maxend
             return false
         end
@@ -564,7 +564,7 @@ end
 @testset "Low Level" begin
     # findidx should return 0 when called on an empty node
     K = Int
-    V = IntervalValue{Int}
+    V = IntervalValue{Int, Int}
     B = 32
     x = Interval{Int}(1, 1)
     node = InternalNode{K, V, B}()
@@ -579,7 +579,7 @@ end
 
     @test IntervalTrees.firstfrom(node, 1) == (node, 0)
 
-    push!(node.entries, IntervalValue{Int, Int}(1, 1, 1))
+    push!(node, IntervalValue{Int, Int}(1, 1, 1))
     @test IntervalTrees.firstfrom(node, 2) == (node, 0)
 
     # test that delete! still works on a contrived tree with one internal and
@@ -589,7 +589,7 @@ end
     push!(t.root.children, LeafNode{K, V, B}())
     push!(t.root.maxends, 1)
     push!(t.root.keys, x)
-    push!(t.root.children[1].entries, IntervalValue{Int, Int}(1, 1, 1))
+    push!(t.root.children[1], IntervalValue{Int, Int}(1, 1, 1))
     t.root.maxend = 1
     t.root.children[1].maxend = 1
     delete!(t, (1,1))
@@ -598,6 +598,6 @@ end
     ## test that the right thing happens if you delete the last key in a non-root
     ## leaf node (which can't actually happen)
     node = LeafNode{Int, IntervalValue{Int}, 32}()
-    push!(node.entries, IntervalValue{Int, Int}(1, 1, 1))
+    push!(node, IntervalValue{Int, Int}(1, 1, 1))
     @test IntervalTrees.findidx(node, x) == 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,11 @@ end
 
 
 function validkeys(node::IntervalTrees.LeafNode, minint, maxint)
-    for entry in node.entries[1:node.count]
+    for (key, entry) in zip(node.keys[1:node.count], node.entries[1:node.count])
+        if first(key) != first(entry) || last(key) != last(entry)
+            return false
+        end
+
         if !(minint <= entry <= maxint) || last(entry) > node.maxend
             return false
         end


### PR DESCRIPTION
Revisiting my old hobby of optimizing IntervalTrees.

So far:
  - Avoid using `isless`, since depending on the interval type it can unnecessarily compare things other than `first` and `last`, e.g. sequence name.
  - Store leaf entries in a plain array, avoiding some overhead from `Slice`.
  - Faster `nextintersection!` function for iterative intersection.

My [simple benchmark](https://gist.github.com/dcjones/e2ffe2cc160ca40e4f44c9db1ca3621c) goes from:
  - **successive intersection**: 5.9s -> ~~5.3s~~ 5.4s
  - **iterative intersection**: 8.4s -> ~~7.3s~~ 5.8s

TODO:
  - [x] Better cost analysis of successive versus iterative intersection. Often it chooses incorrectly and runs the empirically slower algorithm.
  - [ ] Implement a third algorithm: run successive B vs A instead of successive A vs B, which is O(|B| log |A|) instead of O(|A| log |B|).
  - [x] Store leaf keys redundantly in contiguous memory. Uses more memory, but it looks like cache misses from having to follow leaf entry pointers slows things down a lot.
  - [ ] Investigate using StaticArrays to store keys.
  - [ ] Anything else that may occur to me along the way.
